### PR TITLE
Fix crash when 'dbt ls' returns an empty list in output

### DIFF
--- a/prefect_dbt_flow/dbt/graph.py
+++ b/prefect_dbt_flow/dbt/graph.py
@@ -42,6 +42,10 @@ def parse_dbt_project(
         try:
             node_dict = json.loads(line.strip())
 
+            # Skip if the line is not a dict, e.g an empty list []
+            if not isinstance(node_dict, dict):
+                continue
+
             if node_dict["resource_type"] == "model":
                 dbt_graph.append(
                     DbtNode(


### PR DESCRIPTION
For some dbt projects the 'dbt ls --output json' command will return lines that are not json dictionaries, but lists (in my case an empty list []).

This changes skips all non-dictionary lines during the parsing, and prevents crashing when trying to access the dictionary values.