### PR TITLE
feat: Add task_kwargs param to dbt_flow

### DIFF
--- a/prefect_dbt_flow/dbt/tasks.py
+++ b/prefect_dbt_flow/dbt/tasks.py
@@ -214,6 +214,7 @@ def generate_tasks_dag(
     profile: Optional[DbtProfile],
     dag_options: Optional[DbtDagOptions],
     dbt_graph: List[DbtNode],
+    task_kwargs: Optional[Dict] = None,
     run_test_after_model: bool = False,
 ) -> None:
     """
@@ -224,6 +225,7 @@ def generate_tasks_dag(
         profile: A class that represents a dbt profile configuration.
         dag_options: A class to add dbt DAG configurations.
         dbt_graph: A list of dbt nodes (models) to include in the DAG.
+        task_kwargs: Additional task configuration for running each model.
         run_test_after_model: If True, run tests after running each model.
 
     Returns:
@@ -237,6 +239,7 @@ def generate_tasks_dag(
             profile=profile,
             dag_options=dag_options,
             dbt_node=dbt_node,
+            task_kwargs=task_kwargs,
         )
         for dbt_node in dbt_graph
     }

--- a/prefect_dbt_flow/flow.py
+++ b/prefect_dbt_flow/flow.py
@@ -11,6 +11,7 @@ def dbt_flow(
     profile: Optional[DbtProfile] = None,
     dag_options: Optional[DbtDagOptions] = None,
     flow_kwargs: Optional[dict] = None,
+    task_kwargs: Optional[dict] = None,
 ) -> Flow:
     """
     Create a PrefectFlow for executing a dbt project.
@@ -20,6 +21,7 @@ def dbt_flow(
         profile: A Class that represents a dbt profile configuration.
         dag_options: A Class to add dbt DAG configurations.
         flow_kwargs: A dict of prefect @flow arguments
+        task_kwargs: A dict of Prefect @task arguments
 
     Returns:
         dbt_flow: A Prefec Flow.
@@ -44,6 +46,7 @@ def dbt_flow(
             profile,
             dag_options,
             dbt_graph,
+            task_kwargs,
             dag_options.run_test_after_model if dag_options else False,
         )
 


### PR DESCRIPTION
The functions which create Prefect tasks for all dbt resource types (`_task_dbt_snapshot`, `_task_dbt_seed`, and `_task_dbt_run`) all have optional `task_kwargs` parameters, but these don't seem to be used. It would be useful to be able to set these kwargs when creating a dbt flow, for example to specify retry behaviour.

This PR simply adds the `task_kwargs` parameter to `dbt_flow` and passes its value through to `generate_tasks_dag`. Within the latter, this PR supplies `task_kwargs` when creating `all_tasks`, which applies to the tasks corresponding to resource types only.

Resolves #42.

NOTE: I haven't tested this change yet. I'm also new to this repo and may have overlooked something.