### PR TITLE
feat: Implement running Prefect task after models

### DIFF
--- a/prefect_dbt_flow/dbt/__init__.py
+++ b/prefect_dbt_flow/dbt/__init__.py
@@ -4,6 +4,8 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import List, Optional, Union
 
+from prefect import Task
+
 
 class DbtResourceType(Enum):
     """
@@ -73,7 +75,8 @@ class DbtDagOptions:
     Args:
         select: dbt module to include in the run
         exclude: dbt module to exclude in the run
-        run_test_after_model: run test afeter run model
+        run_test_after_model: If True, run dbt tests after running each model.
+        run_task_after_model: A Prefect task to run after each model.
         vars: dbt vars
         install_deps: install dbt dependencies, default behavior install deps
     """
@@ -81,5 +84,6 @@ class DbtDagOptions:
     select: Optional[str] = None
     exclude: Optional[str] = None
     run_test_after_model: bool = False
+    run_task_after_model: Optional[Task] = None
     vars: Optional[dict[str, str]] = None
     install_deps: bool = True

--- a/prefect_dbt_flow/dbt/__init__.py
+++ b/prefect_dbt_flow/dbt/__init__.py
@@ -77,6 +77,7 @@ class DbtDagOptions:
         exclude: dbt module to exclude in the run
         run_test_after_model: If True, run dbt tests after running each model.
         run_task_after_model: A Prefect task to run after each model.
+            Must have exactly one required parameter: model_id (str).
         vars: dbt vars
         install_deps: install dbt dependencies, default behavior install deps
     """

--- a/prefect_dbt_flow/dbt/tasks.py
+++ b/prefect_dbt_flow/dbt/tasks.py
@@ -215,6 +215,7 @@ def generate_tasks_dag(
     dag_options: Optional[DbtDagOptions],
     dbt_graph: List[DbtNode],
     run_test_after_model: bool = False,
+    run_task_after_model: Optional[Task] = None,
 ) -> None:
     """
     Generate a Prefect DAG for running and testing dbt models.
@@ -224,7 +225,8 @@ def generate_tasks_dag(
         profile: A class that represents a dbt profile configuration.
         dag_options: A class to add dbt DAG configurations.
         dbt_graph: A list of dbt nodes (models) to include in the DAG.
-        run_test_after_model: If True, run tests after running each model.
+        run_test_after_model: If True, run dbt tests after running each model.
+        run_task_after_model: A Prefect task to run after each model.
 
     Returns:
         None
@@ -247,7 +249,6 @@ def generate_tasks_dag(
         task_dependencies = [
             submitted_tasks[node_unique_id] for node_unique_id in node.depends_on
         ]
-
         run_task_future = run_task.submit(wait_for=task_dependencies)
 
         if run_test_after_model and node.has_tests:

--- a/prefect_dbt_flow/flow.py
+++ b/prefect_dbt_flow/flow.py
@@ -45,6 +45,7 @@ def dbt_flow(
             dag_options,
             dbt_graph,
             dag_options.run_test_after_model if dag_options else False,
+            dag_options.run_task_after_model if dag_options else False,
         )
 
     return dbt_flow

--- a/prefect_dbt_flow/flow.py
+++ b/prefect_dbt_flow/flow.py
@@ -44,8 +44,6 @@ def dbt_flow(
             profile,
             dag_options,
             dbt_graph,
-            dag_options.run_test_after_model if dag_options else False,
-            dag_options.run_task_after_model if dag_options else False,
         )
 
     return dbt_flow


### PR DESCRIPTION
This PR adds a new optional `run_task_after_model` parameter to the `DbtDagOptions` class. When a Prefect task is provided as an argument, `generate_tasks_dag` will inject that task into the DAG, running it after each model.

The task must have exactly one required parameter: `model_id` of type `str`, which is supplied the value `node.unique_id`. This enables the Prefect task to operate according to the specific model which it is running after. Of course, tasks which don't require this parameter can simply discard it.

The implementation maintains consistency with the existing `run_test_after_model` parameter, and ensures that both can be used independently. If arguments are provided for both, the Prefect task depends on (waits for) the dbt test task.

Additionally, this PR removes the parameter `run_test_after_model` from `generate_tasks_dag`, which already receives `dag_options` where `run_test_after_model` and `run_task_after_model` are both defined. This saves unnecessary argument passing and null checking.

Resolves #51.